### PR TITLE
#1 | Fixed InjectionMapping `ToSingleton` consistency

### DIFF
--- a/src/swiftsuspenders/mapping/InjectionMapping.cs
+++ b/src/swiftsuspenders/mapping/InjectionMapping.cs
@@ -77,7 +77,7 @@ namespace SwiftSuspenders.Mapping
 
 		public UnsealedMapping ToSingleton<T>(bool initializeImmediately = false)
 		{
-			return ToSingleton (typeof(T));
+			return ToSingleton (typeof(T), initializeImmediately);
 		}
 
 		public UnsealedMapping ToSingleton(Type type, bool initializeImmediately = false)


### PR DESCRIPTION
Fixing issue #1 by ensuring the parameter passed into the function is passed into the `override` call